### PR TITLE
update to new atom version, '.editor' deprecated

### DIFF
--- a/keymaps/erb-helper.cson
+++ b/keymaps/erb-helper.cson
@@ -7,7 +7,7 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'atom-text-editor':
   'ctrl->': 'erb-helper:output',
   'ctrl-.': 'erb-helper:eval',
   'ctrl-#': 'erb-helper:comment'


### PR DESCRIPTION
changed the syntax according to the documentation for version 0.176 https://atom.io/docs/latest/advanced/keymaps

Remember to
- [ ] merge this PR
- [ ] update release (create tag, whatever...)
