### PR TITLE
Add end, if, else, elsif shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ ERB Helper makes it easy to insert and wrap ERB tags with Atom.
 
 ## Usage
 
-| Command Name | ERB Value | Key Binding            |
-|--------------|-----------|------------------------|
-| ERB Output   | <%=  %>   | ```CTRL + SHIFT + .``` |
-| ERB Eval     | <%  %>    | ```CTRL + .```         |
-| ERB Comment  | <%#  %>   | ```CTRL + SHIFT + 3``` |
-| ERB End      | <% end %> | ```CTRL + 8```         |
+| Command Name | ERB Value   | Key Binding            |
+|--------------|-------------|------------------------|
+| ERB Output   | <%=  %>     | ```CTRL + SHIFT + .``` |
+| ERB Eval     | <%  %>      | ```CTRL + .```         |
+| ERB Comment  | <%#  %>     | ```CTRL + SHIFT + 3``` |
+| ERB End      | <% end %>   | ```CTRL + 8```         |
+| ERB If       | <% if %>    | ```CTRL + 7```         |
+| ERB Else     | <% else %>  | ```CTRL + 6```         |
+| ERB Elsif    | <% elsif %> | ```CTRL + SHIFT + 6``` |
 
 You can also find the commands in the Right Click context menu.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ ERB Helper makes it easy to insert and wrap ERB tags with Atom.
 | ERB Output   | <%=  %>   | ```CTRL + SHIFT + .``` |
 | ERB Eval     | <%  %>    | ```CTRL + .```         |
 | ERB Comment  | <%#  %>   | ```CTRL + SHIFT + 3``` |
+| ERB End      | <% end %> | ```CTRL + SHIFT + /``` |
 
 You can also find the commands in the Right Click context menu.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ERB Helper makes it easy to insert and wrap ERB tags with Atom.
 | ERB Output   | <%=  %>   | ```CTRL + SHIFT + .``` |
 | ERB Eval     | <%  %>    | ```CTRL + .```         |
 | ERB Comment  | <%#  %>   | ```CTRL + SHIFT + 3``` |
-| ERB End      | <% end %> | ```CTRL + SHIFT + /``` |
+| ERB End      | <% end %> | ```CTRL + 8```         |
 
 You can also find the commands in the Right Click context menu.
 

--- a/keymaps/erb-helper.cson
+++ b/keymaps/erb-helper.cson
@@ -2,3 +2,4 @@
   'ctrl->': 'erb-helper:output'
   'ctrl-.': 'erb-helper:eval'
   'ctrl-#': 'erb-helper:comment'
+  'ctrl-/': 'erb-helper:end'

--- a/keymaps/erb-helper.cson
+++ b/keymaps/erb-helper.cson
@@ -3,3 +3,6 @@
   'ctrl-.': 'erb-helper:eval'
   'ctrl-#': 'erb-helper:comment'
   'ctrl-8': 'erb-helper:end'
+  'ctrl-7': 'erb-helper:if'
+  'ctrl-6': 'erb-helper:else'
+  'ctrl-^': 'erb-helper:elsif'

--- a/keymaps/erb-helper.cson
+++ b/keymaps/erb-helper.cson
@@ -2,4 +2,4 @@
   'ctrl->': 'erb-helper:output'
   'ctrl-.': 'erb-helper:eval'
   'ctrl-#': 'erb-helper:comment'
-  'ctrl-/': 'erb-helper:end'
+  'ctrl-8': 'erb-helper:end'

--- a/lib/erb-helper.coffee
+++ b/lib/erb-helper.coffee
@@ -9,31 +9,34 @@ module.exports =
       'erb-helper:output'  : => @output()
       'erb-helper:eval'    : => @eval()
       'erb-helper:comment' : => @comment()
-      'erb-helper:end' : => @end()
+      'erb-helper:end'     : => @end()
     }
 
   deactivate: ->
     @subscriptions.dispose()
 
   output: ->
-    @insertTag('<%=  %>')
+    @insertTag('<%=  %>', false)
 
   eval: ->
-    @insertTag('<%  %>')
+    @insertTag('<%  %>', false)
 
   comment: ->
-    @insertTag('<%#  %>')
+    @insertTag('<%#  %>', false)
 
   end: ->
-    @insertTag('<% end %>')
+    @insertTag('<% end %>', true)
 
-  insertTag: (tag) ->
-    editor = atom.workspace.getActiveTextEditor()
-    selection = editor.getSelectedText()
-    [openTag, ..., closeTag] = tag.split " "
+  insertTag: (tag, isBlockLevel) ->
+    if !isBlockLevel
+      editor = atom.workspace.gextActiveTextEditor()
+      selection = editor.getSelectedText()
+      [openTag, ..., closeTag] = tag.split " "
 
-    if selection
-      editor.insertText(openTag + " #{selection} " + closeTag)
+      if selection
+        editor.insertText(openTag + " #{selection} " + closeTag)
+      else
+        editor.insertText(tag)
+        editor.moveLeft(3)
     else
       editor.insertText(tag)
-      editor.moveLeft(3)

--- a/lib/erb-helper.coffee
+++ b/lib/erb-helper.coffee
@@ -10,24 +10,36 @@ module.exports =
       'erb-helper:eval'    : => @eval()
       'erb-helper:comment' : => @comment()
       'erb-helper:end'     : => @end()
+      'erb-helper:if'      : => @if()
+      'erb-helper:else'    : => @else()
+      'erb-helper:elsif'   : => @elsif()
     }
 
   deactivate: ->
     @subscriptions.dispose()
 
   output: ->
-    @insertTag('<%=  %>', false)
+    @insertTag('<%=  %>')
 
   eval: ->
-    @insertTag('<%  %>', false)
+    @insertTag('<%  %>')
 
   comment: ->
-    @insertTag('<%#  %>', false)
+    @insertTag('<%#  %>')
 
   end: ->
     @insertTag('<% end %>', true)
 
-  insertTag: (tag, isBlockLevel) ->
+  if: ->
+    @insertTag('<% if %>', true)
+
+  else: ->
+    @insertTag('<% else %>', true)
+
+  elsif: ->
+    @insertTag('<% elsif %>', true)
+
+  insertTag: (tag, isBlockLevel = false) ->
     editor = atom.workspace.getActiveTextEditor()
     selection = editor.getSelectedText()
     [openTag, ..., closeTag] = tag.split " "

--- a/lib/erb-helper.coffee
+++ b/lib/erb-helper.coffee
@@ -28,15 +28,15 @@ module.exports =
     @insertTag('<% end %>', true)
 
   insertTag: (tag, isBlockLevel) ->
-    if !isBlockLevel
-      editor = atom.workspace.gextActiveTextEditor()
-      selection = editor.getSelectedText()
-      [openTag, ..., closeTag] = tag.split " "
+    editor = atom.workspace.getActiveTextEditor()
+    selection = editor.getSelectedText()
+    [openTag, ..., closeTag] = tag.split " "
 
+    if isBlockLevel
+        editor.insertText(tag)
+    else
       if selection
         editor.insertText(openTag + " #{selection} " + closeTag)
       else
         editor.insertText(tag)
         editor.moveLeft(3)
-    else
-      editor.insertText(tag)

--- a/lib/erb-helper.coffee
+++ b/lib/erb-helper.coffee
@@ -9,6 +9,7 @@ module.exports =
       'erb-helper:output'  : => @output()
       'erb-helper:eval'    : => @eval()
       'erb-helper:comment' : => @comment()
+      'erb-helper:end' : => @end()
     }
 
   deactivate: ->
@@ -22,6 +23,9 @@ module.exports =
 
   comment: ->
     @insertTag('<%#  %>')
+
+  end: ->
+    @insertTag('<% end %>')
 
   insertTag: (tag) ->
     editor = atom.workspace.getActiveTextEditor()

--- a/menus/erb-helper.cson
+++ b/menus/erb-helper.cson
@@ -3,5 +3,5 @@
     {label: 'ERB Output Tag',  command: 'erb-helper:output'}
     {label: 'ERB Eval Tag',    command: 'erb-helper:eval' }
     {label: 'ERB Comment Tag', command: 'erb-helper:comment'}
-    {label: 'ERB End Tag', command: 'erb-helper:end'}
+    {label: 'ERB End Tag',     command: 'erb-helper:end'}
   ]

--- a/menus/erb-helper.cson
+++ b/menus/erb-helper.cson
@@ -3,4 +3,5 @@
     {label: 'ERB Output Tag',  command: 'erb-helper:output'}
     {label: 'ERB Eval Tag',    command: 'erb-helper:eval' }
     {label: 'ERB Comment Tag', command: 'erb-helper:comment'}
+    {label: 'ERB End Tag', command: 'erb-helper:end'}
   ]

--- a/menus/erb-helper.cson
+++ b/menus/erb-helper.cson
@@ -4,4 +4,7 @@
     {label: 'ERB Eval Tag',    command: 'erb-helper:eval' }
     {label: 'ERB Comment Tag', command: 'erb-helper:comment'}
     {label: 'ERB End Tag',     command: 'erb-helper:end'}
+    {label: 'ERB If Tag',      command: 'erb-helper:if'}
+    {label: 'ERB Else Tag',    command: 'erb-helper:else'}
+    {label: 'ERB Elsif Tag',   command: 'erb-helper:elsif'}
   ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "atom-workspace": [
       "erb-helper:output",
       "erb-helper:eval",
-      "erb-helper:comment"
+      "erb-helper:comment",
+      "erb-helper:end",
     ]
   },
   "repository": "https://github.com/migeorge/erb-helper",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
       "erb-helper:output",
       "erb-helper:eval",
       "erb-helper:comment",
-      "erb-helper:end"
+      "erb-helper:end",
+      "erb-helper:if",
+      "erb-helper:else",
+      "erb-helper:elsif"
     ]
   },
   "repository": "https://github.com/migeorge/erb-helper",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "erb-helper:output",
       "erb-helper:eval",
       "erb-helper:comment",
-      "erb-helper:end",
+      "erb-helper:end"
     ]
   },
   "repository": "https://github.com/migeorge/erb-helper",


### PR DESCRIPTION
Thanks for the erb-helper package.

I was using it and thought it would be nice to have a shortcut for an end tag as well. Please feel free to ignore this request if you don't think that would add to the functionality or there is a keyboard shortcut I'm unaware of.

**Please note**: I haven't actually run this code because I haven't made an atom package before. I read your code, tried to understand it, and followed your lead. As a result the code I've offered as a possible solution is untested. 